### PR TITLE
Decoders

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -53,6 +53,7 @@ pub fn build(b: *std.Build) void {
     bin.addIncludePath(b.path("."));
     bin.linkLibC();
     bin.linkLibrary(spng);
+    bin.linkSystemLibrary("jpeg");
 
     // Install step
     b.installArtifact(bin);

--- a/build.zig
+++ b/build.zig
@@ -58,6 +58,7 @@ pub fn build(b: *std.Build) void {
     bin.linkLibrary(spng);
     bin.linkSystemLibrary("jpeg");
     bin.linkSystemLibrary("webp");
+    bin.linkSystemLibrary("avif");
 
     // Install step
     b.installArtifact(bin);

--- a/build.zig
+++ b/build.zig
@@ -22,6 +22,7 @@ pub fn build(b: *std.Build) void {
     const options = b.addOptions();
     const version = getVersionString(b) catch "unknown";
     options.addOption([]const u8, "version", version);
+    const strip: bool = if (optimize == std.builtin.OptimizeMode.ReleaseFast) true else false;
 
     // libspng
     const spng = b.addLibrary(.{
@@ -29,6 +30,7 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
+            .strip = strip,
         }),
     });
     const spng_sources = [_][]const u8{
@@ -47,6 +49,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .strip = strip,
         }),
     });
     bin.root_module.addOptions("build_opts", options);
@@ -54,6 +57,7 @@ pub fn build(b: *std.Build) void {
     bin.linkLibC();
     bin.linkLibrary(spng);
     bin.linkSystemLibrary("jpeg");
+    bin.linkSystemLibrary("webp");
 
     // Install step
     b.installArtifact(bin);

--- a/build.zig
+++ b/build.zig
@@ -56,6 +56,8 @@ pub fn build(b: *std.Build) void {
     bin.addIncludePath(b.path("."));
     bin.linkLibC();
     bin.linkLibrary(spng);
+
+    // system decoder libs
     bin.linkSystemLibrary("jpeg");
     bin.linkSystemLibrary("webp");
     bin.linkSystemLibrary("avif");

--- a/src/io.zig
+++ b/src/io.zig
@@ -274,7 +274,7 @@ pub fn loadAVIF(allocator: std.mem.Allocator, path: []const u8) !Image {
     if (r != c.AVIF_RESULT_OK) return error.AvifNoImageDecoded;
 
     // request 8-bit RGB out
-    var rgb: c.avifRGBImage = c.avifRGBImage{};
+    var rgb = c.avifRGBImage{};
     c.avifRGBImageSetDefaults(&rgb, decoder[0].image);
     rgb.format = c.AVIF_RGB_FORMAT_RGB;
     rgb.depth = 8;

--- a/src/io.zig
+++ b/src/io.zig
@@ -7,7 +7,6 @@ const c = @cImport({
 });
 const print = std.debug.print;
 
-// Generic in-memory image representation used by the metric pipeline.
 pub const Image = struct {
     width: usize,
     height: usize,
@@ -342,16 +341,14 @@ pub fn toRGB8(allocator: std.mem.Allocator, img: Image) ![]u8 {
     switch (img.channels) {
         3 => {
             // direct copy
-            var i: usize = 0;
-            while (i < pixels) : (i += 1) {
+            for (0..pixels) |i| {
                 rgb[i * 3 + 0] = img.data[i * 3 + 0];
                 rgb[i * 3 + 1] = img.data[i * 3 + 1];
                 rgb[i * 3 + 2] = img.data[i * 3 + 2];
             }
         },
         4 => {
-            var i: usize = 0;
-            while (i < pixels) : (i += 1) {
+            for (0..pixels) |i| {
                 rgb[i * 3 + 0] = img.data[i * 4 + 0];
                 rgb[i * 3 + 1] = img.data[i * 4 + 1];
                 rgb[i * 3 + 2] = img.data[i * 4 + 2];
@@ -359,8 +356,7 @@ pub fn toRGB8(allocator: std.mem.Allocator, img: Image) ![]u8 {
         },
         1 => {
             // replicate grayscale channel
-            var i: usize = 0;
-            while (i < pixels) : (i += 1) {
+            for (0..pixels) |i| {
                 const g = img.data[i];
                 rgb[i * 3 + 0] = g;
                 rgb[i * 3 + 1] = g;
@@ -369,8 +365,7 @@ pub fn toRGB8(allocator: std.mem.Allocator, img: Image) ![]u8 {
         },
         2 => {
             // grayscale + alpha -> ignore alpha
-            var i: usize = 0;
-            while (i < pixels) : (i += 1) {
+            for (0..pixels) |i| {
                 const g = img.data[i * 2 + 0];
                 rgb[i * 3 + 0] = g;
                 rgb[i * 3 + 1] = g;

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,7 @@ const print = std.debug.print;
 const c = @cImport({
     @cInclude("stdio.h");
     @cInclude("jpeglib.h");
+    @cInclude("webp/decode.h");
 });
 
 const VERSION = @import("build_opts").version;
@@ -102,24 +103,29 @@ fn usage() void {
     print("\x1b[34mfssimu2\x1b[0m | {s}\n\n", .{VERSION});
     print(
         \\usage:
-        \\  fssimu2 [--json] reference.(png|pam|jpg|jpeg) distorted.(png|pam|jpg|jpeg)
+        \\  fssimu2 [--json] reference.(png|pam|jpg|jpeg|webp) distorted.(png|pam|jpg|jpeg|webp)
         \\
         \\options:
         \\  --json          output result as json
         \\  -h, --help      show this help
         \\  -v, --version   show version information
     , .{});
-    print("\n\n\x1b[37m8-bit sRGB PNG, PAM, or JPEG expected (RGB[A] or GRAYSCALE[+ALPHA])\x1b[0m\n", .{});
+    print("\n\n\x1b[37m8-bit sRGB PNG, PAM, JPEG, or WebP expected (RGB[A] or GRAYSCALE[+ALPHA])\x1b[0m\n", .{});
 }
 
 fn printVersion() void {
     const jpeg_version = c.LIBJPEG_TURBO_VERSION_NUMBER;
-    const major = jpeg_version / 1_000_000;
-    const minor = (jpeg_version / 1_000) % 1_000;
-    const patch = jpeg_version % 1_000;
+    const jpeg_major: comptime_int = jpeg_version / 1_000_000;
+    const jpeg_minor: comptime_int = (jpeg_version / 1_000) % 1_000;
+    const jpeg_patch: comptime_int = jpeg_version % 1_000;
     const jpeg_simd: bool = c.WITH_SIMD != 0;
+    const webp_version = c.WebPGetDecoderVersion();
+    const webp_major = webp_version >> 16;
+    const webp_minor = (webp_version >> 8) & 0xFF;
+    const webp_patch = webp_version & 0xFF;
     print("fssimu2 {s}\n", .{VERSION});
-    print("libjpeg-turbo {d}.{d}.{d} [simd: {}]\n", .{ major, minor, patch, jpeg_simd });
+    print("libjpeg-turbo {d}.{d}.{d} [simd: {}]\n", .{ jpeg_major, jpeg_minor, jpeg_patch, jpeg_simd });
+    print("libwebp {d}.{d}.{d}\n", .{ webp_major, webp_minor, webp_patch });
 }
 
 fn usageExtra(msg: []const u8) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,6 +6,7 @@ const c = @cImport({
     @cInclude("stdio.h");
     @cInclude("jpeglib.h");
     @cInclude("webp/decode.h");
+    @cInclude("avif/avif.h");
 });
 
 const VERSION = @import("build_opts").version;
@@ -119,13 +120,20 @@ fn printVersion() void {
     const jpeg_minor: comptime_int = (jpeg_version / 1_000) % 1_000;
     const jpeg_patch: comptime_int = jpeg_version % 1_000;
     const jpeg_simd: bool = c.WITH_SIMD != 0;
+
     const webp_version = c.WebPGetDecoderVersion();
     const webp_major = webp_version >> 16;
     const webp_minor = (webp_version >> 8) & 0xFF;
     const webp_patch = webp_version & 0xFF;
+
+    const avif_major: comptime_int = c.AVIF_VERSION_MAJOR;
+    const avif_minor: comptime_int = c.AVIF_VERSION_MINOR;
+    const avif_patch: comptime_int = c.AVIF_VERSION_PATCH;
     print("fssimu2 {s}\n", .{VERSION});
-    print("libjpeg-turbo {d}.{d}.{d} [simd: {}]\n", .{ jpeg_major, jpeg_minor, jpeg_patch, jpeg_simd });
+    print("libjpeg-turbo {d}.{d}.{d} ", .{ jpeg_major, jpeg_minor, jpeg_patch });
+    print("[simd: {}]\n", .{jpeg_simd});
     print("libwebp {d}.{d}.{d}\n", .{ webp_major, webp_minor, webp_patch });
+    print("libavif {d}.{d}.{d}\n", .{ avif_major, avif_minor, avif_patch });
 }
 
 fn usageExtra(msg: []const u8) void {


### PR DESCRIPTION
- JPEG decode via libjpeg-turbo
- WebP decode via libwebp
- AVIF decode via libavif

Note: performance numbers differ depending on what your input codecs are, because various decoders are faster/slower than one another. JPEG & WebP are competitive with our local libspng, but avif is a bit slower (especially if built against aomdec, which a lot of macOS libavif builds are via Homebrew).

All of `fssimu2`'s public-facing numbers (like in the README) are using the built-in libspng library that comes with the tool. 