### PR TITLE
f16 Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fssimu2
 
-Fast [SSIMULACRA2](https://github.com/cloudinary/ssimulacra2/tree/main) derivative implementation in Zig.
+Fast [SSIMULACRA2](https://github.com/cloudinary/ssimulacra2/tree/main)
+derivative implementation in Zig.
 
 ## Usage
 
@@ -20,6 +21,7 @@ sRGB PNG, PAM, JPEG, WebP, or AVIF input expected
 ```
 
 Example output:
+
 ```sh
 $ ./fssimu2 ref.png dst.png
 79.83781132
@@ -27,96 +29,118 @@ $ ./fssimu2 ref.png dst.png
 
 ## Performance
 
-Performance tested on the Intel Core i7 13700k using a 3840x2160 test image. The numbers indicate that this implementation is up to 23% faster and uses ~40% less memory compared to the [reference implementation](https://github.com/cloudinary/ssimulacra2).
+Performance tested on the Intel Core i7 13700k using a 3840x2160 test image. The
+numbers indicate that this implementation is up to 40% faster (~30% lower wall
+clock time) and uses almost 45% less memory compared to the
+[reference implementation](https://github.com/cloudinary/ssimulacra2). PAM
+images are raw RGB with a simple header, so image decode time isn't factored
+into this benchmark.
 
 ```
-poop "ssimulacra2 medium.png dst.png" "./fssimu2 medium.png dst.png"
-Benchmark 1 (7 runs): ssimulacra2 medium.png dst.png
+poop "ssimulacra2 medium.pam i.pam" "./fssimu2 medium.pam i.pam"
+Benchmark 1 (9 runs): ssimulacra2 medium.pam i.pam
   measurement          mean ± σ            min … max           outliers         delta
-  wall_time           809ms ± 46.8ms     760ms …  857ms          0 ( 0%)        0%
-  peak_rss           1.34GB ± 1.51MB    1.34GB … 1.34GB          0 ( 0%)        0%
-  cpu_cycles         3.90G  ±  243M     3.65G  … 4.15G           0 ( 0%)        0%
-  instructions       9.33G  ± 3.00M     9.32G  … 9.33G           1 (14%)        0%
-  cache_references    118M  ± 1.33M      116M  …  119M           0 ( 0%)        0%
-  cache_misses       60.0M  ± 3.00M     57.0M  … 63.4M           0 ( 0%)        0%
-  branch_misses      16.6M  ±  101K     16.5M  … 16.8M           0 ( 0%)        0%
-Benchmark 2 (9 runs): ./fssimu2 medium.png dst.png
+  wall_time           615ms ± 12.4ms     601ms …  637ms          0 ( 0%)        0%
+  peak_rss           1.30GB ± 1.65MB    1.30GB … 1.31GB          1 (11%)        0%
+  cpu_cycles         2.83G  ± 42.9M     2.80G  … 2.92G           0 ( 0%)        0%
+  instructions       6.61G  ± 21.9M     6.57G  … 6.62G           2 (22%)        0%
+  cache_references    113M  ±  664K      112M  …  114M           2 (22%)        0%
+  cache_misses       65.5M  ±  296K     64.9M  … 65.7M           0 ( 0%)        0%
+  branch_misses       198K  ± 25.2K      164K  …  220K           0 ( 0%)        0%
+Benchmark 2 (12 runs): ./fssimu2 medium.pam i.pam
   measurement          mean ± σ            min … max           outliers         delta
-  wall_time           618ms ± 10.4ms     603ms …  631ms          0 ( 0%)        ⚡- 23.6% ±  4.2%
-  peak_rss            817MB ±  118KB     816MB …  817MB          0 ( 0%)        ⚡- 39.1% ±  0.1%
-  cpu_cycles         3.05G  ± 45.1M     2.99G  … 3.10G           0 ( 0%)        ⚡- 21.7% ±  4.5%
-  instructions       6.17G  ± 24.8M     6.11G  … 6.18G           3 (33%)        ⚡- 33.8% ±  0.2%
-  cache_references   74.7M  ± 13.7K     74.7M  … 74.7M           1 (11%)        ⚡- 36.6% ±  0.8%
-  cache_misses       34.9M  ±  686K     34.1M  … 35.8M           0 ( 0%)        ⚡- 41.9% ±  3.7%
-  branch_misses      11.4M  ±  138K     11.0M  … 11.5M           1 (11%)        ⚡- 31.2% ±  0.8%
+  wall_time           429ms ± 9.27ms     419ms …  447ms          0 ( 0%)        ⚡- 30.2% ±  1.6%
+  peak_rss            722MB ±  146KB     721MB …  722MB          1 ( 8%)        ⚡- 44.6% ±  0.1%
+  cpu_cycles         2.03G  ± 40.3M     2.00G  … 2.11G           2 (17%)        ⚡- 28.3% ±  1.3%
+  instructions       4.26G  ± 3.76M     4.26G  … 4.27G           0 ( 0%)        ⚡- 35.5% ±  0.2%
+  cache_references   73.9M  ±  170K     73.6M  … 74.1M           2 (17%)        ⚡- 34.6% ±  0.4%
+  cache_misses       34.2M  ±  479K     33.2M  … 34.7M           2 (17%)        ⚡- 47.8% ±  0.6%
+  branch_misses       180K  ± 14.9K      166K  …  203K           0 ( 0%)          -  8.9% ±  9.3%
 ```
 
-Conformance to the reference SSIMULACRA2 implementation can be tested with `validate.py` by supplying the `fssimu2` binary.
+Conformance to the reference SSIMULACRA2 implementation can be tested with
+`validate.py` by supplying the `fssimu2` binary.
 
-`validate.py` requires [`uv`](https://docs.astral.sh/uv/) and [`libjxl`](https://github.com/libjxl/libjxl).
+`validate.py` requires [`uv`](https://docs.astral.sh/uv/) and
+[`libjxl`](https://github.com/libjxl/libjxl).
 
 ```sh
 validate.py --custom ~/git-cloning/fssimu2/zig-out/bin/fssimu2 ~/git-cloning/gb82-image-set/png/*
 ```
 
-Output on the [gb82 image set](https://github.com/gianni-rosato/gb82-image-set) invoking the above command:
+Output on the [gb82 image set](https://github.com/gianni-rosato/gb82-image-set)
+invoking the above command:
+
 ```
 SAMPLES: 75
 LEVELS: 1.0 2.0 4.0
 
 == custom vs ref ==
  pairs: 75
- ref mean: 77.5116  std: 10.6899
- custom mean: 76.9932  std: 11.1606
- mean diff (other - ref): -0.518406
- diff stddev: 0.541576
- diff stderr: 0.0625359
- percentage error (mean diff / ref mean): 0.669%
- max absolute error: 1.9165
+ ref mean: 77.5166  std: 10.6811
+ custom mean: 77.0059  std: 11.1468
+ mean diff (other - ref): -0.510732
+ diff stddev: 0.542364
+ diff stderr: 0.0626268
+ percentage error (mean diff / ref mean): 0.659%
+ max absolute error: 1.90087
 
 == correlation ==
- PCC (Pearson): 0.999700
- SRCC (Spearman): 0.999403
- KRCC (Kendall): 0.987748
+ PCC (Pearson): 0.999676
+ SRCC (Spearman): 0.999061
+ KRCC (Kendall): 0.982703
 ```
 
 ## Error Map
 
-The library optionally allows specifying an error map output image as either an uncompressed `.tga` (Targa) or PNG.
+The library optionally allows specifying an error map output image as either an
+uncompressed `.tga` (Targa) or PNG.
 
-Error maps use the [Turbo](https://research.google/blog/turbo-an-improved-rainbow-colormap-for-visualization/) color map for error visualization, which emphasizes visually obvious errors well.
+Error maps use the
+[Turbo](https://research.google/blog/turbo-an-improved-rainbow-colormap-for-visualization/)
+color map for error visualization, which emphasizes visually obvious errors
+well.
 
-An example output is provided here, generated using `./fssimu2 --err-map map.png ref.png dst_bad.png` which resulted in a score of `49.37005220`.
+An example output is provided here, generated using
+`./fssimu2 --err-map map.png ref.png dst_bad.png` which resulted in a score of
+`49.37005220`.
 
 ![Sample Error Map](./map.webp)
 
 ## Compilation
 
 Compilation requires:
-- Zig (version [0.15.1](https://ziglang.org/download/0.15.1/release-notes.html))
+
+- Zig (version [0.15.x](https://ziglang.org/download/0.15.2/release-notes.html))
 - [libjpeg-turbo](https://libjpeg-turbo.org)
 - [libwebp](https://chromium.googlesource.com/webm/libwebp)
 - [libavif](https://github.com/AOMediaCodec/libavif)
 
 Build locally:
+
 ```sh
 zig build --release=fast
 ```
 
-The binary will emit to `zig-out/bin/fssimu2`. The library will emit to `zig-out/lib/libssimu2.so` (or `.dylib` on macOS, `.dll` on Windows) and the include will be copied to `zig-out/include/ssimu2.h`.
+The binary will emit to `zig-out/bin/fssimu2`. The library will emit to
+`zig-out/lib/libssimu2.so` (or `.dylib` on macOS, `.dll` on Windows) and the
+include will be copied to `zig-out/include/ssimu2.h`.
 
 Build and install to `/usr/local/`
+
 ```sh
 zig build --release=fast --prefix /usr/local
 ```
 
 ## Library Usage
 
-`fssimu2` provides a C-compatible ABI with the `ssimu2.h` include file, as well as a Zig package for use with Zig's dependency management system.
+`fssimu2` provides a C-compatible ABI with the `ssimu2.h` include file, as well
+as a Zig package for use with Zig's dependency management system.
 
 ### Zig
 
-Adding the `fssimu2` dependency allows your Zig project to make use of the public `computeSsimu2()` in `ssimulacra2.zig`.
+Adding the `fssimu2` dependency allows your Zig project to make use of the
+public `computeSsimu2()` in `ssimulacra2.zig`.
 
 ```zig
 pub fn computeSsimu2(
@@ -134,14 +158,15 @@ pub fn computeSsimu2(
 In order to add it to your project, follow the steps below.
 
 1. Run one of the following commands:
-    ```sh
-    # Pull from latest `main`
-    zig fetch --save https://github.com/gianni-rosato/fssimu2/archive/refs/heads/main.tar.gz
-    # Pull from a specific tag
-    zig fetch --save https://github.com/gianni-rosato/fssimu2/archive/refs/tags/0.1.1.tar.gz
-    ```
+   ```sh
+   # Pull from latest `main`
+   zig fetch --save https://github.com/gianni-rosato/fssimu2/archive/refs/heads/main.tar.gz
+   # Pull from a specific tag
+   zig fetch --save https://github.com/gianni-rosato/fssimu2/archive/refs/tags/0.1.2.tar.gz
+   ```
 
-2. Add these lines somewhere in the `build()` function in `build.zig` to expose the module to the build system:
+2. Add these lines somewhere in the `build()` function in `build.zig` to expose
+   the module to the build system:
    ```zig
    const fssimu2 = b.dependency("fssimu2", .{
        .target = target,
@@ -157,13 +182,15 @@ In order to add it to your project, follow the steps below.
    ```
 
 Now, you can import the SSIMULACRA2 computation like so:
+
 ```zig
 const fssimu2 = @import("fssimu2");
 ```
 
 ### C
 
-Once you've compiled and installed `fssimu2`, include the header in any relevant file to get started:
+Once you've compiled and installed `fssimu2`, include the header in any relevant
+file to get started:
 
 ```c
 #include <ssimu2.h>
@@ -205,9 +232,11 @@ Builds will require `-lssimu2` passed to the compiler.
 
 ### Example Usage
 
-An example C program is provided in the `c_abi_example/` directory, featuring a simple PAM decoder and SSIMULACRA2 computation. See the `test.c` file for usage.
+An example C program is provided in the `c_abi_example/` directory, featuring a
+simple PAM decoder and SSIMULACRA2 computation. See the `test.c` file for usage.
 
 In order to build the test example, enter the `c_abi_example/` dir and run:
+
 ```sh
 cc test.c pam_dec.c -I../zig-out/include -L../zig-out/lib -lssimu2 -o test
 # Set library path for Linux
@@ -217,6 +246,7 @@ DYLD_LIBRARY_PATH=../zig-out/lib ./test ref.pam dst.pam
 ```
 
 For the error map example, enter the `c_abi_example/` dir and run:
+
 ```sh
 cc test_with_map.c pam_dec.c -I../zig-out/include -L../zig-out/lib -lssimu2 -o test_map
 # Set library path for Linux
@@ -225,10 +255,15 @@ LD_LIBRARY_PATH=../zig-out/lib ./test_map ref.pam dst.pam
 DYLD_LIBRARY_PATH=../zig-out/lib ./test_map ref.pam dst.pam
 ```
 
-When fssimu2 is properly installed system-wide, the library path specifier isn't needed.
+When fssimu2 is properly installed system-wide, the library path specifier isn't
+needed.
 
 ## License
 
-This project is under the Apache 2.0 license. More details in [LICENSE](./LICENSE).
+This project is under the Apache 2.0 license. More details in
+[LICENSE](./LICENSE).
 
-This project uses code from [libspng](https://libspng.org), [libminiz](https://github.com/richgel999/miniz), and [vapoursynth-zip](https://github.com/dnjulek/vapoursynth-zip). Special thanks to the authors. Licenses for third party code are included in the `legal/` folder.
+This project uses code from [libspng](https://libspng.org),
+[libminiz](https://github.com/richgel999/miniz), and
+[vapoursynth-zip](https://github.com/dnjulek/vapoursynth-zip). Special thanks to
+the authors. Licenses for third party code are included in the `legal/` folder.

--- a/src/linearlight.zig
+++ b/src/linearlight.zig
@@ -3,21 +3,22 @@ const math = std.math;
 
 // sRGB to Linear Light scaling for proper metric computation
 
-fn makeSRGBToLinearLUT() [256]f32 {
+fn makeSRGBToLinearLUT() [256]f16 {
     @setEvalBranchQuota(std.math.maxInt(u32));
-    var lut: [256]f32 = undefined;
+    var lut: [256]f16 = undefined;
     for (0..256) |i| {
         const c: f32 = @as(f32, @floatFromInt(i)) / 255.0;
-        lut[i] = if (c <= 0.04045) c / 12.92 else math.pow(f32, (c + 0.055) / 1.055, 2.4);
+        const linear = if (c <= 0.04045) c / 12.92 else math.pow(f32, (c + 0.055) / 1.055, 2.4);
+        lut[i] = @floatCast(linear);
     }
     return lut;
 }
 
-const SRGB_LUT: [256]f32 = makeSRGBToLinearLUT();
+const SRGB_LUT: [256]f16 = makeSRGBToLinearLUT();
 
 pub fn sRGBInterleavedToPlanarLinear(
     src: []const u8,
-    dst_planes: [3][]f32,
+    dst_planes: [3][]f16,
     width: u32,
     height: u32,
     channels: u32,

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,7 @@ pub fn main() !void {
     defer args.deinit(allocator);
     while (args_iter.next()) |a| try args.append(allocator, a);
 
+    const cpu_threads = std.Thread.getCpuCount() catch 1;
     var json_output = false;
     var error_map_path: ?[]const u8 = null;
     var thread_count_opt: ?usize = null;
@@ -56,8 +57,8 @@ pub fn main() !void {
             const n = std.fmt.parseInt(usize, args.items[i], 10) catch {
                 return usageExtra("--threads must be a positive integer");
             };
-            if (n == 0) return usageExtra("--threads must be >= 1");
             thread_count_opt = n;
+            if (n == 0) thread_count_opt = cpu_threads;
         } else {
             if (pos_index >= 2)
                 return usageExtra("Too many positional arguments provided.");
@@ -79,7 +80,6 @@ pub fn main() !void {
         if (!io.hasExtension(ref_path, ".y4m") or !io.hasExtension(dist_path, ".y4m"))
             return fail("Both inputs must be .y4m for video mode", .{}, 2);
 
-        const cpu_threads = std.Thread.getCpuCount() catch 1;
         const thread_count: usize = blk: {
             const t = thread_count_opt orelse cpu_threads;
             break :blk if (t == 0) 1 else t;

--- a/src/ssimulacra2.zig
+++ b/src/ssimulacra2.zig
@@ -19,7 +19,7 @@ pub const Workspace = struct {
     height: u32,
     stride: u32,
     plane_size: usize,
-    planes: []f32,
+    planes: []f16,
     temp: []f32,
     scratch: []f32,
 
@@ -30,7 +30,7 @@ pub const Workspace = struct {
             .height = 0,
             .stride = 0,
             .plane_size = 0,
-            .planes = &[_]f32{},
+            .planes = &[_]f16{},
             .temp = &[_]f32{},
             .scratch = &[_]f32{},
         };
@@ -54,7 +54,7 @@ pub const Workspace = struct {
 
         const pixels = @as(usize, width) * @as(usize, height);
         const total_floats: usize = pixels * 3 * 2;
-        const plane_alloc = try self.allocator.alignedAlloc(f32, .of(f32), total_floats);
+        const plane_alloc = try self.allocator.alignedAlloc(f16, .of(f16), total_floats);
 
         const wh: usize = @as(usize, width) * @as(usize, height);
         const temp_alloc = try self.allocator.alignedAlloc(f32, .of(f32), wh * 20);
@@ -89,8 +89,8 @@ pub fn computeSsimu2WithWorkspace(
 
     try workspace.ensureCapacity(width, height);
 
-    var ref_planes: [3][]f32 = undefined;
-    var dist_planes: [3][]f32 = undefined;
+    var ref_planes: [3][]f16 = undefined;
+    var dist_planes: [3][]f16 = undefined;
     {
         var off: usize = 0;
         inline for (0..3) |i| {
@@ -106,10 +106,10 @@ pub fn computeSsimu2WithWorkspace(
     scl.sRGBInterleavedToPlanarLinear(reference, ref_planes, width, height, channels);
     scl.sRGBInterleavedToPlanarLinear(distorted, dist_planes, width, height, channels);
 
-    const ref_const: [3][]const f32 = .{
+    const ref_const: [3][]const f16 = .{
         ref_planes[0], ref_planes[1], ref_planes[2],
     };
-    const dist_const: [3][]const f32 = .{
+    const dist_const: [3][]const f16 = .{
         dist_planes[0], dist_planes[1], dist_planes[2],
     };
 
@@ -150,7 +150,7 @@ inline fn multiply(src1: []const f32, src2: []const f32, dst: []f32, stride: u32
     }
 }
 
-fn blurH(srcp: []f32, dstp: []f32, kernel: [K_SIZE]f32, w: i32) void {
+fn blurH(srcp: []const f32, dstp: []f32, kernel: [K_SIZE]f32, w: i32) void {
     var j: i32 = 0;
     while (j < @min(w, RADIUS)) : (j += 1) {
         const dist_from_right: i32 = w - 1 - j;
@@ -202,7 +202,7 @@ inline fn blurV(src: anytype, dstp: []f32, kernel: [K_SIZE]f32, w: u32) void {
         var accum: f32 = 0.0;
         var k: u32 = 0;
         while (k < K_SIZE) : (k += 1) {
-            accum += kernel[k] * src[k][j];
+            accum += kernel[k] * @as(f32, @floatCast(src[k][j]));
         }
         dstp[j] = accum;
     }
@@ -250,15 +250,15 @@ inline fn blur(src: []const f32, dst: []f32, stride: u32, w: u32, h: u32, tmp_ro
 }
 
 const K_D0: f32 = 0.0037930734;
-const K_D1: f32 = std.math.lossyCast(f32, math.cbrt(@as(f32, K_D0)));
+const K_D1: f32 = std.math.lossyCast(f32, math.cbrt(K_D0));
 
-const V00 = 0.0;
-const V05 = 0.5;
-const V10 = 1.0;
-const V001 = 0.01;
-const V055 = 0.55;
-const V042 = 0.42;
-const V140 = 14.0;
+const V00: f32 = 0.0;
+const V05: f32 = 0.5;
+const V10: f32 = 1.0;
+const V001: f32 = 0.01;
+const V055: f32 = 0.55;
+const V042: f32 = 0.42;
+const V140: f32 = 14.0;
 
 const weight = [108]f64{
     0.0,
@@ -396,18 +396,21 @@ const OPSIN_ABSORBANCE_MATRIX = [_]f32{
     K_M10, K_M11, K_M12,
     K_M20, K_M21, K_M22,
 };
-const OPSIN_ABSORBANCE_BIAS: f32 = @as(f32, K_D0);
-const ABSORBANCE_BIAS: f32 = @as(f32, -K_D1);
+const OPSIN_ABSORBANCE_BIAS: f32 = K_D0;
+const ABSORBANCE_BIAS: f32 = -K_D1;
 
 inline fn cbrtVec(x: f32) f32 {
-    return std.math.lossyCast(f32, math.cbrt(@as(f32, x)));
+    return std.math.lossyCast(f32, math.cbrt(x));
 }
 
 inline fn opsinAbsorbance(rgb: [3]f32) [3]f32 {
     var out: [3]f32 = undefined;
-    out[0] = @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[0], rgb[0], @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[1], rgb[1], @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[2], rgb[2], OPSIN_ABSORBANCE_BIAS)));
-    out[1] = @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[3], rgb[0], @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[4], rgb[1], @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[5], rgb[2], OPSIN_ABSORBANCE_BIAS)));
-    out[2] = @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[6], rgb[0], @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[7], rgb[1], @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[8], rgb[2], OPSIN_ABSORBANCE_BIAS)));
+    const r = rgb[0];
+    const g = rgb[1];
+    const b = rgb[2];
+    out[0] = @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[0], r, @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[1], g, @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[2], b, OPSIN_ABSORBANCE_BIAS)));
+    out[1] = @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[3], r, @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[4], g, @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[5], b, OPSIN_ABSORBANCE_BIAS)));
+    out[2] = @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[6], r, @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[7], g, @mulAdd(f32, OPSIN_ABSORBANCE_MATRIX[8], b, OPSIN_ABSORBANCE_BIAS)));
     return out;
 }
 
@@ -493,15 +496,15 @@ inline fn ssimMap(
         const row = y * stride;
         var x: u32 = 0;
         while (x < w) : (x += 1) {
-            const m1: f32 = mu1[row + x];
-            const m2: f32 = mu2[row + x];
+            const m1: f32 = @floatCast(mu1[row + x]);
+            const m2: f32 = @floatCast(mu2[row + x]);
             const m11 = m1 * m1;
             const m22 = m2 * m2;
             const m12 = m1 * m2;
             const m_diff = m1 - m2;
             const num_m: f64 = @mulAdd(f32, m_diff, -m_diff, 1.0);
-            const num_s: f64 = @mulAdd(f32, (s12[row + x] - m12), 2.0, 0.0009);
-            const denom_s: f64 = (s11[row + x] - m11) + (s22[row + x] - m22) + 0.0009;
+            const num_s: f64 = @mulAdd(f32, (@as(f32, @floatCast(s12[row + x])) - m12), 2.0, 0.0009);
+            const denom_s: f64 = (@as(f32, @floatCast(s11[row + x])) - m11) + (@as(f32, @floatCast(s22[row + x])) - m22) + 0.0009;
             const d1: f64 = @max(1.0 - ((num_m * num_s) / denom_s), 0.0);
             sum1[0] += d1;
             sum1[1] += tothe4th(d1);
@@ -539,8 +542,8 @@ inline fn edgeMap(
         const row = y * stride;
         var x: u32 = 0;
         while (x < w) : (x += 1) {
-            const d1: f64 = (1.0 + @as(f64, @abs(im2[row + x] - mu2[row + x]))) /
-                (1.0 + @as(f64, @abs(im1[row + x] - mu1[row + x]))) - 1.0;
+            const d1: f64 = (1.0 + @as(f64, @abs(@as(f32, @floatCast(im2[row + x])) - @as(f32, @floatCast(mu2[row + x]))))) /
+                (1.0 + @as(f64, @abs(@as(f32, @floatCast(im1[row + x])) - @as(f32, @floatCast(mu1[row + x]))))) - 1.0;
             const artifact: f64 = @max(d1, 0.0);
             sum2[0] += artifact;
             sum2[1] += tothe4th(artifact);
@@ -633,8 +636,8 @@ inline fn downscale(src: [3][]f32, dst: [3][]f32, src_stride: u32, in_w: u32, in
 
 fn process(
     allocator: std.mem.Allocator,
-    srcp1: [3][]const f32,
-    srcp2: [3][]const f32,
+    srcp1: [3][]const f16,
+    srcp2: [3][]const f16,
     stride: u32,
     w: u32,
     h: u32,
@@ -651,8 +654,8 @@ fn process(
 }
 
 fn processWithScratch(
-    srcp1: [3][]const f32,
-    srcp2: [3][]const f32,
+    srcp1: [3][]const f16,
+    srcp2: [3][]const f16,
     stride: u32,
     w: u32,
     h: u32,
@@ -698,8 +701,10 @@ fn processWithScratch(
     const tmppmu1 = temp6x3[5][1];
 
     inline for (0..3) |i| {
-        @memcpy(srcp1b[i], srcp1[i]);
-        @memcpy(srcp2b[i], srcp2[i]);
+        for (srcp1[i], 0..) |v, j|
+            srcp1b[i][j] = @floatCast(v);
+        for (srcp2[i], 0..) |v, j|
+            srcp2b[i][j] = @floatCast(v);
     }
 
     var plane_avg_ssim: [6][6]f64 = undefined;
@@ -774,11 +779,10 @@ fn processWithScratch(
         }
 
         if (error_map != null) {
-            if (scale == 0) {
-                @memcpy(error_accum, error_scale);
-            } else if (scale < 3) {
+            if (scale == 0)
+                @memcpy(error_accum, error_scale)
+            else if (scale < 3)
                 err_map.upscaleAndAccumulate(error_scale, error_accum, stride2, w2, h2, stride, w, h);
-            }
         }
     }
 


### PR DESCRIPTION
- Use `f16` instead of `f32` for image plane storage
- `-t 0` / `--threads 0` automatically uses all CPU cores
- Add explicit type annotations to scalar constants
- Make `blurH()` source parameter const-correct (`[]const f32`)
- Remove redundant `@as()` casts where types are already inferred
- Refactor `opsinAbsorbance()` to use local variables for clarity
- Add `f32` casts when loading `f16` values for computation

~13-16% lower memory usage in tested images, worst-case regression is ~1%. Scores remain largely the same (see updated README correlation via `validate.py`).